### PR TITLE
fix typo in OCM url

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Example layersControl object:
 layersControl = {
 	baseLayers: {
 		'Open Street Map': tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 18, attribution: '...' }),
-		'Open Cycle Map': tileLayer('http://{s}.tile.opencyclemap.org/{z}/{x}/{y}.png', { maxZoom: 18, attribution: '...' })
+		'Open Cycle Map': tileLayer('http://{s}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png', { maxZoom: 18, attribution: '...' })
 	},
 	overlays: {
 		'Big Circle': circle([ 46.95, -122 ], { radius: 5000 }),


### PR DESCRIPTION
I think that's a typo in the OpenCycleMap urlpath.
I don't know much about this, I just found out it's not working without `cycle` in the url and it's working when it's added.

(Discovered the working way in the examples:
-> https://github.com/Asymmetrik/ngx-leaflet/blob/develop/src/demo/app/leaflet/layers/baselayers-demo.component.ts#L16
-> https://github.com/Asymmetrik/ngx-leaflet/blob/develop/src/demo/app/leaflet/layers/layers-demo.component.ts#L18
)

I don't know if this is the correct solution (if it's a solution in the first place). A not working example in the readme is kind of annoying though :smile: .