### PR TITLE
Fix 8.1 header (Lvl 3 instead of lvl 2)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## 8.0
 Support for Angular.io 10.
 
-## 8.1
+### 8.1
 Added call to Map.remove in OnDestroy handler.
 This should ensure that any outstanding event handlers are cleaned up.
 Added demo example for adding/removing maps dynamically. 


### PR DESCRIPTION
The changes list lists the 8.1 header at the same level as 8.0. This changes it to be in line with the rest of versions